### PR TITLE
Updated mV -> Battery description

### DIFF
--- a/custom_components/sensor/owlintuition.py
+++ b/custom_components/sensor/owlintuition.py
@@ -304,9 +304,9 @@ class OwlIntuitionSensor(Entity):
             batt_lvl = int(xml.find("battery").attrib['level'])
             if batt_lvl > 2900:
                 self._state = 'High'
-            elif batt_lvl > 2500:
+            elif batt_lvl > 2750:
                 self._state = 'Medium'
-            elif batt_lvl > 2300:
+            elif batt_lvl > 2600:
                 self._state = 'Low'
             else:
                 self._state = 'Very Low'            


### PR DESCRIPTION
Some brief research suggests that 'normal' batteries should still work in the 1.3v - 1.5v range, therefore suggest the combined voltage should be:

>2900 High
>2750 Medium
>2600 Low 
< 2600 Very Low 

This corresponds with my experience where a 2.6mV battery powering a sensor was low enough to drop off the network.

https://electronics.stackexchange.com/questions/125863/how-should-i-use-a-multimeter-to-determine-which-aa-batteries-to-keep-and-which