### PR TITLE
Add sensor template for grid power and total energy used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # OWL Intuition
+
 A set of sensors to integrate the OWL Intuition devices network
 
 ## Installation (for Linux or Hassio systems)
-1. On the Home Assitant server, install the Terminal&SSH Add-On
+
+1. On the Home Assistant server, install the Terminal&SSH Add-On
 2. In a terminal do the following to download the files, and put them in the right place and clean up afterwards
 ```
 cd /config
@@ -15,6 +17,7 @@ cd /config
 rm -rf temp_dir
 ```
 3. Follow the documentation for using the integration - documentation in Home Assistant format available at [sensor.owlintuition.markdown](./sensor.owlintuition.markdown). (Note you may have to restart the HA server to get this to work)
+4. (Optional) If using the Home Energy feature (introduced in Home Assistant 2021.8.0) and using the Owl Intuition in a Type 1 configuration, then you may want to create a grid power sensor by copying the [package](https://www.home-assistant.io/docs/configuration/packages/) file [owl_intuition.yaml](custom_components/owlintuition/owl_intuition.yaml) in to your `packages` directory. This will create sensors for the current grid usage and the running total for the day.
 
 ## Troubleshooting
 
@@ -22,8 +25,8 @@ Some discussion and troubleshooting about this integration took place in the [Ho
 
 In particular, if HA seems to not receive any data, a first step is to validate that OWL is effectively sending out UDP updates to the configured port, and that the data can be received from the HA end. The [snippet here](test/testowl.py) may help to check that (edit it to suit your needs).
 
-
 ## Changelog:
+
 * 1.4 - 05/05/2019: added resources.json and updated code layout following 'the great migration'
 * 1.3 - 13/01/2019: included support for triphase on the old XML format [@hadjimanolisg]
 * 1.2 - 30/11/2018: added electricity cost and last update time (in UTC) sensors

--- a/custom_components/owlintuition/owl_intuition.yaml
+++ b/custom_components/owlintuition/owl_intuition.yaml
@@ -2,40 +2,47 @@
 # Owl Intution - Grid Energy Sensor                #
 ####################################################
 template:
-  - sensor:
-    - name: "Owl Grid Power Now"
-      unit_of_measurement: "W"
-      state_class: measurement
-      device_class: power
-      state: >
-        {% if is_state('sensor.owl_intuition_electricity_power', 'unknown') or is_state('sensor.owl_intuition_solar_generating', 'unknown') %}
-          nan
-        {% else %}
-          {% set elec = states('sensor.owl_intuition_electricity_power') | float %}
-          {% set solar = states('sensor.owl_intuition_solar_generating') | float %}
-          {% if (float(elec) - float(solar)) < 0 %}
-            0
-          {% elif (float(elec) - float(solar)) > 0 %}
-            {{ float(elec) - float(solar) }}
-          {% endif %}
-        {% endif %}
-
-    - name: "Owl Grid Energy Today"
-      unit_of_measurement: "kWh"
-      state_class: total_increasing
-      device_class: energy
-      state: >
-        {% if is_state('sensor.owl_intuition_electricity_today', 'unknown') or is_state('sensor.owl_intuition_solar_generated_today', 'unknown') %}
-          nan
-        {% else %}
-          {% set elec = states('sensor.owl_intuition_electricity_today') | float %}
-          {% set solar = states('sensor.owl_intuition_solar_generated_today') | float %}
-          {% set last_grid_today = states('sensor.owl_grid_energy_today') | float %}
-          {% if (float(elec) - float(solar)) > 0 %}
-            {% if (float(elec) - float(solar)) > float(last_grid_today) %}
+  - trigger:
+    - platform: state
+      entity_id: sensor.owl_intuition_electricity_power
+    sensor:
+      - name: "Owl Grid Power Now"
+        unit_of_measurement: "W"
+        state_class: measurement
+        device_class: power
+        state: >
+          {% if is_state('sensor.owl_intuition_electricity_power', 'unknown') or is_state('sensor.owl_intuition_solar_generating', 'unknown') %}
+            nan
+          {% else %}
+            {% set elec = states('sensor.owl_intuition_electricity_power') | float %}
+            {% set solar = states('sensor.owl_intuition_solar_generating') | float %}
+            {% if (float(elec) - float(solar)) < 0 %}
+              0
+            {% elif (float(elec) - float(solar)) > 0 %}
               {{ float(elec) - float(solar) }}
-            {% else %}
-              {{ float(last_grid_today) }}
             {% endif %}
           {% endif %}
-        {% endif %}
+
+  - trigger: 
+    - platform: state
+      entity_id: sensor.owl_intuition_electricity_today
+    sensor:
+      - name: "Owl Grid Energy Today"
+        unit_of_measurement: "kWh"
+        state_class: total_increasing
+        device_class: energy
+        state: >
+          {% if is_state('sensor.owl_intuition_electricity_today', 'unknown') or is_state('sensor.owl_intuition_solar_generated_today', 'unknown') %}
+            nan
+          {% else %}
+            {% set elec = states('sensor.owl_intuition_electricity_today') | float %}
+            {% set solar = states('sensor.owl_intuition_solar_generated_today') | float %}
+            {% set last_grid_today = states('sensor.owl_grid_energy_today') | float %}
+            {% if (float(elec) - float(solar)) > 0 %}
+              {% if (float(elec) - float(solar)) > float(last_grid_today) %}
+                {{ float(elec) - float(solar) }}
+              {% else %}
+                {{ float(last_grid_today) }}
+              {% endif %}
+            {% endif %}
+          {% endif %}

--- a/custom_components/owlintuition/owl_intuition.yaml
+++ b/custom_components/owlintuition/owl_intuition.yaml
@@ -1,0 +1,41 @@
+####################################################
+# Owl Intution - Grid Energy Sensor                #
+####################################################
+template:
+  - sensor:
+    - name: "Owl Grid Power Now"
+      unit_of_measurement: "W"
+      state_class: measurement
+      device_class: power
+      state: >
+        {% if is_state('sensor.owl_intuition_electricity_power', 'unknown') or is_state('sensor.owl_intuition_solar_generating', 'unknown') %}
+          nan
+        {% else %}
+          {% set elec = states('sensor.owl_intuition_electricity_power') | float %}
+          {% set solar = states('sensor.owl_intuition_solar_generating') | float %}
+          {% if (float(elec) - float(solar)) < 0 %}
+            0
+          {% elif (float(elec) - float(solar)) > 0 %}
+            {{ float(elec) - float(solar) }}
+          {% endif %}
+        {% endif %}
+
+    - name: "Owl Grid Energy Today"
+      unit_of_measurement: "kWh"
+      state_class: total_increasing
+      device_class: energy
+      state: >
+        {% if is_state('sensor.owl_intuition_electricity_today', 'unknown') or is_state('sensor.owl_intuition_solar_generated_today', 'unknown') %}
+          nan
+        {% else %}
+          {% set elec = states('sensor.owl_intuition_electricity_today') | float %}
+          {% set solar = states('sensor.owl_intuition_solar_generated_today') | float %}
+          {% set last_grid_today = states('sensor.owl_grid_energy_today') | float %}
+          {% if (float(elec) - float(solar)) > 0 %}
+            {% if (float(elec) - float(solar)) > float(last_grid_today) %}
+              {{ float(elec) - float(solar) }}
+            {% else %}
+              {{ float(last_grid_today) }}
+            {% endif %}
+          {% endif %}
+        {% endif %}

--- a/custom_components/owlintuition/owl_intuition.yaml
+++ b/custom_components/owlintuition/owl_intuition.yaml
@@ -38,8 +38,8 @@ template:
             {% set elec = states('sensor.owl_intuition_electricity_today') | float %}
             {% set solar = states('sensor.owl_intuition_solar_generated_today') | float %}
             {% set last_grid_today = states('sensor.owl_grid_energy_today') | float %}
-            {% if (float(elec) - float(solar)) > 0 %}
-              {% if (float(elec) - float(solar)) > float(last_grid_today) %}
+            {% if (float(elec) - float(solar)) >= 0 %}
+              {% if ((float(elec) - float(solar)) > float(last_grid_today)) or ((float(elec) - float(solar)) < 1 ) %}
                 {{ float(elec) - float(solar) }}
               {% else %}
                 {{ float(last_grid_today) }}


### PR DESCRIPTION
In a Type 1 configuration (with 2 current clamps, one measuring solar, one measuring home consumption) it is necessary to calculate the grid electricity usage for the Home Energy component introduced in HA 2021.8. 

Add example package using template sensor to calculate the grid value. 
The template sensor needs to:
* Handle data not available for either electricity or solar sensors, as these are updated separately as relevant packets are processes
* Handle energy being exported and ensure it doesn't cause negative values and ensure the total_increasing, can't decrease
* Solar total generated for the day resetting before electricity values. (Protected by trigger)
* Electricity total used for the data resetting before solar generated. (Protected by not allowing the value to go negative)

Due to solar and electricity packets arriving at different times and the protection needed for this, expect that the grid sensors will not report values when the daily totals reset, but only for a few minutes.