### PR TITLE
Added support for multizone sensors

### DIFF
--- a/custom_components/owlintuition/sensor.py
+++ b/custom_components/owlintuition/sensor.py
@@ -150,6 +150,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_MODE, default=MODE_MONO):
         vol.In([MODE_MONO, MODE_TRI]),
+    vol.Optional(CONF_ZONE): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=DEFAULT_MONITORED):
         vol.All(cv.ensure_list, [vol.In(OWL_CLASSES)]),
     vol.Optional(CONF_COST_ICON, default='mdi:coin'): cv.string,
@@ -194,7 +195,7 @@ async def async_setup_platform(
     # Iterate through the possible sensors and add if class is monitored
     for sensor in SENSOR_TYPES:
         if SENSOR_TYPES[sensor][3] in config.get(CONF_MONITORED_CONDITIONS):
-            entities.append(OwlIntuitionSensor(owldata, config.get(CONF_NAME), sensor))
+            entities.append(OwlIntuitionSensor(owldata, config.get(CONF_NAME), sensor, sensor_zone=config.get(CONF_ZONE))
             _LOGGER.debug("Adding sensor %s", sensor)
     
     # In case of electricity sensors, handle triphase mode
@@ -202,9 +203,9 @@ async def async_setup_platform(
        OWLCLASS_ELECTRICITY in config.get(CONF_MONITORED_CONDITIONS):
         for phase in range(1, 4):
             entities.append(OwlIntuitionSensor(owldata, config.get(CONF_NAME),
-                                          SENSOR_ELECTRICITY_POWER, phase))
+                                               SENSOR_ELECTRICITY_POWER, phase=phase))
             entities.append(OwlIntuitionSensor(owldata, config.get(CONF_NAME),
-                                          SENSOR_ELECTRICITY_ENERGY_TODAY, phase))
+                                               SENSOR_ELECTRICITY_ENERGY_TODAY, phase=phase))
     async_add_entities(entities, True)
 
 
@@ -275,26 +276,23 @@ class OwlData:
 class OwlIntuitionSensor(SensorEntity):
     """Implementation of the OWL Intuition Power Meter sensors."""
 
-    def __init__(self, owldata, sensor_name, sensor_type, phase=0):
+    def __init__(self, owldata, sensor_name, sensor_type, phase=0, sensor_zone=''):
         """Set all the config values if they exist and get initial state."""
         self._owldata = owldata
-        if(phase > 0):
-            self._name = '{} {} P{}'.format(
-                sensor_name,
-                SENSOR_TYPES[sensor_type][0],
-                phase)
-        else:
-            self._name = '{} {}'.format(
-                sensor_name,
-                SENSOR_TYPES[sensor_type][0])
         self._sensor_type = sensor_type
         self._phase = phase
-        self._owl_class = SENSOR_TYPES[sensor_type][3]
+        self._sensor_zone = sensor_zone
+        self._name = f'{sensor_name} {SENSOR_TYPES[sensor_type][0]}'
+        if phase > 0:
+            self._name += f' P{phase}'
+        if sensor_zone != '':
+            self._name += f' ({sensor_zone})'
         self._state = None
         self._attr_attribution = POWERED_BY
-        self._attr_device_class = SENSOR_TYPES[self._sensor_type][4]
-        self._attr_native_unit_of_measurement = SENSOR_TYPES[self._sensor_type][1]
-        self._attr_state_class = SENSOR_TYPES[self._sensor_type][5]
+        self._attr_native_unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self._owl_class = SENSOR_TYPES[sensor_type][3]
+        self._attr_device_class = SENSOR_TYPES[sensor_type][4]
+        self._attr_state_class = SENSOR_TYPES[sensor_type][5]
 
     @property
     def _attr_name(self):
@@ -319,8 +317,16 @@ class OwlIntuitionSensor(SensorEntity):
             return
         xml_ver = xml.attrib.get('ver')
         if (xml.tag == OWLCLASS_HEATING or xml.tag == OWLCLASS_HOTWATER or xml.tag == OWLCLASS_RELAYS):
-            # Only supports first zone currently
-            xml = xml.find('zones/zone')
+            # Extract the relevant zone for the multizone sensors
+            found = False
+            for zone in xml.find('zones'):
+                if zone.attrib['id'] == self._sensor_zone:
+                    xml = zone
+                    found = True
+                    break
+            if not found:
+                # fallback to the first one
+                xml = xml.find('zones/zone')
 
         # Radio sensors
         if self._attr_device_class == SensorDeviceClass.SIGNAL_STRENGTH:
@@ -404,7 +410,7 @@ class OwlIntuitionSensor(SensorEntity):
         elif self._sensor_type == SENSOR_SOLAR_EENERGY_TODAY:
             self._state = round(float(xml.find('day/exported').text)/1000, 2)
 	  		
-        # Hotwater sensors
+        # Hot water sensors
         if self._sensor_type == SENSOR_HOTWATER_CURRENT:
             self._state = round(float(xml.find('temperature/current').text),1)
         elif self._sensor_type == SENSOR_HOTWATER_REQUIRED:
@@ -425,6 +431,7 @@ class OwlIntuitionSensor(SensorEntity):
             # Heating state reported in version 2 and up
             if xml_ver is not None:
                 self._state = HEATING_STATE[int(xml.find('temperature').attrib['state'])]
+
 
 class OwlStateUpdater(asyncio.DatagramProtocol):
     """An helper class for the async UDP listener loop.

--- a/sensor.owlintuition.markdown
+++ b/sensor.owlintuition.markdown
@@ -47,14 +47,16 @@ By default only the electricity sensors will be monitored. The host parameter is
 
 {% linkable_title Configuration variables %}
 
-Currently, this platform supports electric probes and solar generators. For the electric clamps, triphase installations are supported as well and one needs to specify `mode: triphase` in the configuration (the default mode is `monophase`).
-
 This platform exposes multiple sensors according to the monitored conditions. The type of conditions that can be monitored are:
 
 - **electricity**: Electrical energy being used.
 - **solar**: Solar power being generated and used.
 - **heating**: Heating system.
 - **hot_water**: Hot water system.
+
+For the sensors exposing multi-zone data, you can specify the `zone` in the configuration (see below).
+
+For the electric clamps, triphase installations are supported as well and one needs to specify `mode: triphase` in the configuration (the default mode is `monophase`).
 
 {% linkable_title Complete example %}
 
@@ -66,6 +68,7 @@ sensor:
     mode: triphase
     cost_icon: 'mdi:currency-eur'
     cost_unit_of_measurement: EUR
+    zone: '20029D2'
     monitored_conditions:
       - electricity
       - heating

--- a/sensor.owlintuition.markdown
+++ b/sensor.owlintuition.markdown
@@ -54,7 +54,7 @@ This platform exposes multiple sensors according to the monitored conditions. Th
 - **heating**: Heating system.
 - **hot_water**: Hot water system.
 
-For the sensors exposing multi-zone data, you can specify the `zone` in the configuration (see below).
+For sensors exposing multi-zone data, you should specify how many `zones` are returned by OWL in the configuration (see below).
 
 For the electric clamps, triphase installations are supported as well and one needs to specify `mode: triphase` in the configuration (the default mode is `monophase`).
 
@@ -68,7 +68,7 @@ sensor:
     mode: triphase
     cost_icon: 'mdi:currency-eur'
     cost_unit_of_measurement: EUR
-    zone: '20029D2'
+    zones: 2
     monitored_conditions:
       - electricity
       - heating


### PR DESCRIPTION
Fixes #23.

@LankyGamer83 would you be able to test this branch? I don't have myself a multi-zone sensor (and I'm going to try that the rest does not break) so I'd appreciate some feedback from you.

~~Also, for now there is no logic to self-discover the zones and you'd have to specify them as multiple sensors, which is suboptimal.~~
Edit: you just need to set `zones: 2` (i.e. the total count of zones you have) in your configuration, and multiple sensors will get defined to match the zones.