### PR TITLE
Remove coroutine decorator removed in Python 3.11

### DIFF
--- a/custom_components/owlintuition/sensor.py
+++ b/custom_components/owlintuition/sensor.py
@@ -164,7 +164,6 @@ SOCK_TIMEOUT = 60
 _LOGGER = logging.getLogger(__name__)
 
 
-@asyncio.coroutine
 async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,


### PR DESCRIPTION
Fixed #30 
coroutine decorator was deprecated in Python 3.8 and removed from Python 3.11, per: https://docs.python.org/3.10/library/asyncio-task.html#generator-based-coroutines