### PR TITLE
Update sensor.py to Fix Issue #40

### DIFF
--- a/custom_components/owlintuition/sensor.py
+++ b/custom_components/owlintuition/sensor.py
@@ -103,7 +103,7 @@ SENSOR_TYPES = {
     SENSOR_ELECTRICITY_RADIO: ['Electricity Radio', SIGNAL_STRENGTH_DECIBELS_MILLIWATT, 'mdi:signal', OWLCLASS_ELECTRICITY, SensorDeviceClass.SIGNAL_STRENGTH, SensorStateClass.MEASUREMENT],
     SENSOR_ELECTRICITY_POWER: ['Electricity Power', UnitOfPower.WATT, 'mdi:flash', OWLCLASS_ELECTRICITY, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
     SENSOR_ELECTRICITY_ENERGY_TODAY: ['Electricity Today', UnitOfEnergy.KILO_WATT_HOUR, 'mdi:flash', OWLCLASS_ELECTRICITY, SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING],
-    SENSOR_ELECTRICITY_COST_TODAY: ['Cost Today', None, 'mdi:coin', OWLCLASS_ELECTRICITY, SensorDeviceClass.MONETARY, SensorStateClass.TOTAL_INCREASING],
+    SENSOR_ELECTRICITY_COST_TODAY: ['Cost Today', None, 'mdi:coin', OWLCLASS_ELECTRICITY, SensorDeviceClass.MONETARY, SensorStateClass.TOTAL],
     SENSOR_SOLAR_GPOWER: ['Solar Generating', UnitOfPower.WATT, 'mdi:flash', OWLCLASS_SOLAR, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
     SENSOR_SOLAR_GENERGY_TODAY: ['Solar Generated Today', UnitOfEnergy.KILO_WATT_HOUR, 'mdi:flash', OWLCLASS_SOLAR, SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING],
     SENSOR_SOLAR_EPOWER: ['Solar Exporting', UnitOfPower.WATT, 'mdi:flash', OWLCLASS_SOLAR, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],

--- a/custom_components/owlintuition/sensor.py
+++ b/custom_components/owlintuition/sensor.py
@@ -103,7 +103,7 @@ SENSOR_TYPES = {
     SENSOR_ELECTRICITY_RADIO: ['Electricity Radio', SIGNAL_STRENGTH_DECIBELS_MILLIWATT, 'mdi:signal', OWLCLASS_ELECTRICITY, SensorDeviceClass.SIGNAL_STRENGTH, SensorStateClass.MEASUREMENT],
     SENSOR_ELECTRICITY_POWER: ['Electricity Power', UnitOfPower.WATT, 'mdi:flash', OWLCLASS_ELECTRICITY, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
     SENSOR_ELECTRICITY_ENERGY_TODAY: ['Electricity Today', UnitOfEnergy.KILO_WATT_HOUR, 'mdi:flash', OWLCLASS_ELECTRICITY, SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING],
-    SENSOR_ELECTRICITY_COST_TODAY: ['Cost Today', None, 'mdi:coin', OWLCLASS_ELECTRICITY, SensorDeviceClass.MONETARY, None],
+    SENSOR_ELECTRICITY_COST_TODAY: ['Cost Today', None, 'mdi:coin', OWLCLASS_ELECTRICITY, SensorDeviceClass.MONETARY, SensorStateClass.TOTAL_INCREASING],
     SENSOR_SOLAR_GPOWER: ['Solar Generating', UnitOfPower.WATT, 'mdi:flash', OWLCLASS_SOLAR, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
     SENSOR_SOLAR_GENERGY_TODAY: ['Solar Generated Today', UnitOfEnergy.KILO_WATT_HOUR, 'mdi:flash', OWLCLASS_SOLAR, SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING],
     SENSOR_SOLAR_EPOWER: ['Solar Exporting', UnitOfPower.WATT, 'mdi:flash', OWLCLASS_SOLAR, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],


### PR DESCRIPTION
Added state_class to today’s cost. SensorStateClass.TOTAL in sensor.py.

Refer to HA Developer notes here … https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes

In the statistic section…. lower down in the developer notes ….

Entities representing a total amount

Entities tracking a total amount have a value that may optionally reset periodically, like this month's energy consumption, today's energy production, the weight of pellets used to heat the house over the last week or the yearly growth of a stock portfolio. The sensor's value when the first statistics is compiled is used as the initial zero-point.


